### PR TITLE
[refactor] Update TypedDict import and bump version

### DIFF
--- a/promptfile/types.py
+++ b/promptfile/types.py
@@ -1,4 +1,5 @@
-from typing import Literal, TypedDict
+from typing import Literal
+from typing_extensions import TypedDict
 
 
 class Message(TypedDict):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="promptfile",
-    version="0.6.0",
+    version="0.7.0",
     packages=find_namespace_packages(),
     entry_points={},
     description="promptfile: language support for .prompt files",


### PR DESCRIPTION
Update the import of TypedDict from typing_extensions instead of typing. Bump the package version from 0.6.0 to 0.7.0.

Notes: This change appears to be addressing a compatibility issue with the TypedDict import. By using typing_extensions, the code likely ensures better compatibility across different Python versions. The version bump suggests that this change is considered significant enough to warrant a minor version increase.