### PR TITLE
[refactor] Suppress warning for unreplaced placeholders

### DIFF
--- a/promptfile/prompt.py
+++ b/promptfile/prompt.py
@@ -104,9 +104,10 @@ class Prompt(BaseModel):
             msg["content"] = content
 
             if remaining_placeholders:
-                print(
-                    f"Warning: The following placeholders in message {i} were not replaced: {', '.join(remaining_placeholders)}"
-                )
+                pass
+                # print(
+                #     f"The following placeholders in message {i} were not replaced: {', '.join(remaining_placeholders)}"
+                # )
 
         return new
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="promptfile",
-    version="0.7.0",
+    version="0.7.1",
     packages=find_namespace_packages(),
     entry_points={},
     description="promptfile: language support for .prompt files",


### PR DESCRIPTION
- Comment out the warning message for unreplaced placeholders in Prompt class
- Bump version from 0.7.0 to 0.7.1 in setup.py
- Add 'rich' to install_requires in setup.py

Notes: The changes appear to be minor refactoring and dependency updates. The warning message for unreplaced placeholders is now commented out, which suggests a decision to suppress this information during execution. The version bump and addition of 'rich' to the dependencies indicate ongoing maintenance and potentially new features or improvements that rely on the 'rich' library.